### PR TITLE
Ensure arduino-mk can handle the i2cEncoderLibV2

### DIFF
--- a/src/i2cEncoderLibV2.cpp
+++ b/src/i2cEncoderLibV2.cpp
@@ -19,13 +19,22 @@
 /** Class costructor **/
 i2cEncoderLibV2::i2cEncoderLibV2(uint8_t add) {
 	_add = add;
+    // ensure defined values
+    _stat = 0x00;
+    _stat2 = 0x00;
+    _gconf = 0x00;
 }
 
 /** Used for initialize the encoder **/
 void i2cEncoderLibV2::begin(uint16_t conf) {
+    uint8_t temp;
 
-	writeEncoder(REG_GCONF, (uint8_t) conf & 0xFF);
-	writeEncoder(REG_GCONF2, (uint8_t)(conf >> 8) & 0xFF);
+    temp = (uint8_t) conf & 0xff;
+	writeEncoder(REG_GCONF, temp);
+
+    temp = (uint8_t) (conf >> 8) & 0xff;
+	writeEncoder(REG_GCONF, temp);
+
 	_gconf = conf;
 	if ((conf & CLK_STRECH_ENABLE) == 0)
 		_clockstreach = 0;
@@ -326,7 +335,7 @@ void i2cEncoderLibV2::writeInterruptConfig(uint8_t interrupt) {
 
 /** Check if there is some attached callback and enable the corresponding interrupt **/
 void i2cEncoderLibV2::autoconfigInterrupt(void) {
-	uint8_t reg;
+	uint8_t reg = 0;
 
 	if (onButtonRelease != NULL)
 		reg |= PUSHR;

--- a/src/i2cEncoderLibV2.h
+++ b/src/i2cEncoderLibV2.h
@@ -162,7 +162,7 @@ public:
 		uint8_t bval[4];
 	};
 
-	uint8_t id = 0x00;
+	uint8_t id; // = 0x00;
 	typedef void (*Callback)(i2cEncoderLibV2*);
 
 	/* Event */
@@ -294,10 +294,10 @@ public:
 private:
 
 	uint8_t _clockstreach; 
-	uint8_t _add = 0x00;
-	uint8_t _stat = 0x00;
-	uint8_t _stat2 = 0x00;
-	uint8_t _gconf = 0x00;
+	uint8_t _add ; // = 0x00;
+	uint8_t _stat ; // = 0x00;
+	uint8_t _stat2 ; // = 0x00;
+	uint8_t _gconf ; // = 0x00;
 	union Data_v _tem_data;
 
 	void eventCaller(Callback *event);


### PR DESCRIPTION
Circumvent some errors and warnings when using arduino-mk on Debian GNU/Linux

Evaluation was done by using the Basic_with_Callbacks example. 
Arduino-IDE is nice, but I'm more used to command-line.