### PR TITLE
Removed AntibouncingPeriod declarations for mini.

### DIFF
--- a/src/i2cEncoderMiniLib.cpp
+++ b/src/i2cEncoderMiniLib.cpp
@@ -226,7 +226,7 @@ void i2cEncoderMiniLib::writeDoublePushPeriod(uint8_t dperiod) {
   writeEncoder(REG_DPPERIOD, dperiod);
 }
 
-/** Write Anti-bouncing period register **/
+/** Change MiniEncoder I2C address **/
 void i2cEncoderMiniLib::ChangeI2CAddress(uint8_t add) {
   writeEncoder(REG_I2CADDRESS, add);
   writeEncoder(REG_I2CADDRESS, add);

--- a/src/i2cEncoderMiniLib.h
+++ b/src/i2cEncoderMiniLib.h
@@ -126,7 +126,6 @@ class i2cEncoderMiniLib {
     int32_t readStep(void);
 
     /** Timing registers **/
-    uint8_t readAntibouncingPeriod(void);
     uint8_t readDoublePushPeriod(void);
     uint8_t readIDCode(void);
     uint8_t readVersion(void);
@@ -144,7 +143,6 @@ class i2cEncoderMiniLib {
     void writeStep(int32_t step);
 
     /** Timing registers **/
-    void writeAntibouncingPeriod(uint8_t bounc);
     void writeDoublePushPeriod(uint8_t dperiod);
     void ChangeI2CAddress(uint8_t add);
     /** EEPROM register **/


### PR DESCRIPTION
The mini did not implement readAntibouncingPeriod or writeAntibouncingPeriod,
so deleted the method declarations.

Also fixed comment for i2cEncoderMiniLib::ChangeI2CAddress.