### PR TITLE
Mini: Removed incorrect "A0 is soldered" comment.

### DIFF
--- a/examples/I2CEncoderMini/Basic_with_Callbacks/Basic_with_Callbacks.ino
+++ b/examples/I2CEncoderMini/Basic_with_Callbacks/Basic_with_Callbacks.ino
@@ -16,7 +16,7 @@
 
 const int IntPin = A3; /* Definition of the interrupt pin. You can change according to your board */
 //Class initialization with the I2C addresses
-i2cEncoderMiniLib Encoder(0x20); /* A0 is soldered */
+i2cEncoderMiniLib Encoder(0x20);
 
 //Callback when the CVAL is incremented
 void encoder_increment(i2cEncoderMiniLib* obj) {


### PR DESCRIPTION
This was a cut-and-paste error from the V2 example. The mini has
no solder jumper for controlling the I2C address.